### PR TITLE
Added OneSync Infinity compatibility

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -101,6 +101,9 @@ end
 
 RegisterNetEvent('3dme:shareDisplay')
 AddEventHandler('3dme:shareDisplay', function(text, serverId)
-    local ped = GetPlayerPed(GetPlayerFromServerId(serverId))
-    Display(ped, text)
+    local player = GetPlayerFromServerId(serverId)
+    if player ~= -1 then
+        local ped = GetPlayerPed(player)
+        Display(ped, text)
+    end
 end)


### PR DESCRIPTION
Players outside of the local players range will return -1, which when passed to `GetPlayerPed` returns the local players ped, causing all out-of-range players' messages to appear above the local player's head instead.
This patch should not impact non-OneSync behavior.